### PR TITLE
Fix spam use sleep

### DIFF
--- a/Detection/UserBot/api_rawontol.py
+++ b/Detection/UserBot/api_rawontol.py
@@ -18,7 +18,7 @@ Contact: killerx@randydev.my.id
 """
 
 import logging
-
+import asyncio
 from pyrogram import Client
 from pyrogram.raw.types import (
     Channel,
@@ -161,7 +161,7 @@ async def check_raw(client: Client, update, users, chats):
         if isinstance(chat, ChannelForbidden):
             if cid in IGNORE_CHANNEL_DEV_LIST:
                 return
-            await assistant.send_message(
+            return await assistant.send_message(
                 client.me.id,
                 f"#BANNED_ALERT\n"
                 f"**Channel:** {chat.title}\n"
@@ -182,7 +182,7 @@ async def check_raw(client: Client, update, users, chats):
         elif isinstance(chat, ChatForbidden):
             if cid in IGNORE_CHANNEL_DEV_LIST:
                 return
-            await assistant.send_message(
+            return await assistant.send_message(
                 client.me.id,
                 f"#BANNED_ALERT\n"
                 f"**Chat:** {chat.title}\n"
@@ -203,7 +203,8 @@ async def check_raw(client: Client, update, users, chats):
         elif isinstance(chat, Channel) and getattr(chat, "left", False):
             if cid in IGNORE_CHANNEL_DEV_LIST:
                 return
-            await assistant.send_message(
+            await asyncio.sleep(1.5)
+            return await assistant.send_message(
                 client.me.id,
                 f"#UNBANNED #LEFT_ALERT\n"
                 f"**Channel:** {chat.title}\n"
@@ -222,7 +223,7 @@ async def check_raw(client: Client, update, users, chats):
                 )
             )
         elif isinstance(chat, Channel) and getattr(chat, "restricted", False):
-            await assistant.send_message(
+            return await assistant.send_message(
                 client.me.id,
                 f"#RESTRICTED_ALERT\n"
                 f"**Channel:** {chat.title}\n"
@@ -241,7 +242,7 @@ async def check_raw(client: Client, update, users, chats):
                 )
             )
         elif isinstance(chat, Channel) and getattr(chat, "scam", False):
-            await assistant.send_message(
+            return await assistant.send_message(
                 client.me.id,
                 f"#SCAM_ALERT\n"
                 f"**Channel:** {chat.title}\n"
@@ -260,7 +261,7 @@ async def check_raw(client: Client, update, users, chats):
                 )
             )
         elif isinstance(chat, Channel) and getattr(chat, "fake", False):
-            await assistant.send_message(
+            return await assistant.send_message(
                 client.me.id,
                 f"#FAKE_ALERT\n"
                 f"**Channel:** {chat.title}\n"
@@ -281,7 +282,8 @@ async def check_raw(client: Client, update, users, chats):
         elif isinstance(chat, Channel) and getattr(chat, "broadcast", False):
             if cid in BLACKLIST_CHANNEL_NOPOST:
                 return
-            await assistant.send_message(
+            await asyncio.sleep(1.5)
+            return await assistant.send_message(
                 client.me.id,
                 f"#BROADCAST_ALERT\n"
                 f"**Channel:** {chat.title}\n"

--- a/Detection/UserBot/api_rawontol.py
+++ b/Detection/UserBot/api_rawontol.py
@@ -17,8 +17,9 @@ Authorized use only permitted with express written consent from TeamKillerX.
 Contact: killerx@randydev.my.id
 """
 
-import logging
 import asyncio
+import logging
+
 from pyrogram import Client
 from pyrogram.raw.types import (
     Channel,


### PR DESCRIPTION
## Summary by Sourcery

Stop redundant post-alert execution by returning after sending messages and add short delays to reduce alert spam for unbanned and broadcast channels.

Enhancements:
- Return immediately after sending alert messages to prevent further processing.
- Introduce a 1.5s delay before unbanned and broadcast alerts to throttle message spam.